### PR TITLE
Implement fast update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@
 ```
 
 ### Run
-- Option `-d` allows the containers to run under detachment mode
 ```bash
-./dev.sh build up [-d]
+./dev.sh build up
+```
+
+### Refresh
+- Refresh Cruise-Control host for code changes
+```
+./dev.sh refresh <PATH_TO_SOURCE>
 ```
 
 ### Destroy

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,6 +7,7 @@ ARG SOURCE_CC_PATH=tmp
 ARG TARGET_CC_PATH=/home/${SERVICE_USER}/cruise-control
 ENV SERVICE_USER ${SERVICE_USER}
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
+RUN apt-get install -y rsync
 RUN wget ${KAFKA_BIN}
 RUN tar -zxvf kafka_2.11-${KAFKA_VERSION}.tgz
 RUN mv -v /home/${SERVICE_USER}/kafka_2.11-${KAFKA_VERSION} \
@@ -15,6 +16,6 @@ COPY ${SOURCE_CC_PATH} ${TARGET_CC_PATH}
 RUN cd /home/${SERVICE_USER}; rm -rf kafka_2.11-${KAFKA_VERSION}.tgz
 RUN cd /home/${SERVICE_USER}; rm -rf *.tar.gz
 RUN cd ${TARGET_CC_PATH}; ./gradlew jar
+RUN cd ${TARGET_CC_PATH}; gradle jar copyDependantLibs
 RUN cp ${TARGET_CC_PATH}/cruise-control-metrics-reporter/build/libs/cruise-control-metrics-reporter-*.jar \
     /home/${SERVICE_USER}/kafka-current/libs
-RUN cd ${TARGET_CC_PATH}; ./gradlew build -x test

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -6,8 +6,8 @@ ARG SERVICE_USER=gradle
 ARG SOURCE_CC_PATH=tmp
 ARG TARGET_CC_PATH=/home/${SERVICE_USER}/cruise-control
 ENV SERVICE_USER ${SERVICE_USER}
+ENV GRADLE_USER_HOME=/home/${SERVICE_USER}/cache
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
-RUN apt-get install -y rsync
 RUN wget ${KAFKA_BIN}
 RUN tar -zxvf kafka_2.11-${KAFKA_VERSION}.tgz
 RUN mv -v /home/${SERVICE_USER}/kafka_2.11-${KAFKA_VERSION} \
@@ -15,7 +15,7 @@ RUN mv -v /home/${SERVICE_USER}/kafka_2.11-${KAFKA_VERSION} \
 COPY ${SOURCE_CC_PATH} ${TARGET_CC_PATH}
 RUN cd /home/${SERVICE_USER}; rm -rf kafka_2.11-${KAFKA_VERSION}.tgz
 RUN cd /home/${SERVICE_USER}; rm -rf *.tar.gz
-RUN cd ${TARGET_CC_PATH}; ./gradlew jar
+RUN cd ${TARGET_CC_PATH}; ./gradlew jar -x test
 RUN cd ${TARGET_CC_PATH}; gradle jar copyDependantLibs
 RUN cp ${TARGET_CC_PATH}/cruise-control-metrics-reporter/build/libs/cruise-control-metrics-reporter-*.jar \
     /home/${SERVICE_USER}/kafka-current/libs

--- a/docker/cruise-control/Dockerfile
+++ b/docker/cruise-control/Dockerfile
@@ -9,6 +9,6 @@ RUN chmod +x /entrypoint.sh
 RUN rm -rf /home/${SERVICE_USER}/cruise-control
 COPY ${SOURCE_CC_PATH} ${TARGET_CC_PATH}
 RUN cp /home/${SERVICE_USER}/cruise-control/config/cruisecontrol.properties /
-RUN cd /home/${SERVICE_USER}/cruise-control; ./gradlew jar
+RUN cd /home/${SERVICE_USER}/cruise-control; ./gradlew jar -x test
 EXPOSE 8090
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/cruise-control/Dockerfile
+++ b/docker/cruise-control/Dockerfile
@@ -1,10 +1,14 @@
 FROM ctrl-c:cc-base
 USER root
 ARG SERVICE_USER=gradle
+ARG SOURCE_CC_PATH=tmp
+ARG TARGET_CC_PATH=/home/${SERVICE_USER}/cruise-control-new
 ENV SERVICE_USER ${SERVICE_USER}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
+COPY ${SOURCE_CC_PATH} ${TARGET_CC_PATH}
+RUN rsync -auv ${TARGET_CC_PATH} /home/${SERVICE_USER}/cruise-control
 RUN cp /home/${SERVICE_USER}/cruise-control/config/cruisecontrol.properties /
-RUN cd /home/${SERVICE_USER}/cruise-control; gradle jar copyDependantLibs
+RUN cd /home/${SERVICE_USER}/cruise-control; ./gradlew build -x test
 EXPOSE 8090
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/cruise-control/Dockerfile
+++ b/docker/cruise-control/Dockerfile
@@ -2,13 +2,13 @@ FROM ctrl-c:cc-base
 USER root
 ARG SERVICE_USER=gradle
 ARG SOURCE_CC_PATH=tmp
-ARG TARGET_CC_PATH=/home/${SERVICE_USER}/cruise-control-new
+ARG TARGET_CC_PATH=/home/${SERVICE_USER}/cruise-control
 ENV SERVICE_USER ${SERVICE_USER}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
+RUN rm -rf /home/${SERVICE_USER}/cruise-control
 COPY ${SOURCE_CC_PATH} ${TARGET_CC_PATH}
-RUN rsync -auv ${TARGET_CC_PATH} /home/${SERVICE_USER}/cruise-control
 RUN cp /home/${SERVICE_USER}/cruise-control/config/cruisecontrol.properties /
-RUN cd /home/${SERVICE_USER}/cruise-control; ./gradlew build -x test
+RUN cd /home/${SERVICE_USER}/cruise-control; ./gradlew jar
 EXPOSE 8090
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
### Gave up on the idea to update when the container is running because
- As soon as you stop the service, which is part of the entrypoint, the container will just exit. You need something like an infinite loop to keep it alive
- Random permission issues trying to build code with docker exec
- Too hacky since containers are not designed to be persistent environments like VMs

### Alternate solution
- Move build logic into the cc image
- Copy the src directory again in the cc dockerfile and rsync with the existing src folder (a bit hacky but better than the above)
- Rebuild just the cc image, and restart just the cc container (still pretty fast)